### PR TITLE
Update deprecated requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,17 @@ If you cannot use Slack Legacy Tokens, you can generate a token by using [OAuth]
 
 |Permission|Reason|
 |---|---|
-|`channels:read`|Check channel for unread messages|
+|`channels:history`|Check channel for unread messages|
+|`channels:read`|Get channel info|
 |`channels:write`|Mark channel as read|
-|`groups:read`|Check groups for unread messages|
+|`groups:history`|Check groups for unread messages|
+|`groups:read`|Get group info|
 |`groups:write`|Mark group as read|
-|`im:read`|Check IM for unread messages|
+|`im:history`|Check IM for unread messages|
+|`im:read`|Get IM info|
 |`im:write`|Mark IM as read|
-|`mpim:read`|Check mpim for unread messages|
+|`mpim:history`|Check mpim for unread messages|
+|`mpim:read`|Get mpim info|
 |`mpim:write`|Mark mpim as read|
 |`users:read`|If unread IM, get username for user|
 |`team:read`|Get team name|

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitbar-slack-team-notifications",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Show notifications for Slack teams and channels with option to mark as read.",
   "main": "slack-team-notifications.1m.js",
   "scripts": {

--- a/slack-team-notifications.1m.js
+++ b/slack-team-notifications.1m.js
@@ -3,7 +3,7 @@
 /* jshint asi: true */
 
 // <bitbar.title>Slack Team Notifications</bitbar.title>
-// <bitbar.version>v1.0.7</bitbar.version>
+// <bitbar.version>v1.0.8</bitbar.version>
 // <bitbar.author>Benji Encalada Mora</bitbar.author>
 // <bitbar.author.github>benjifs</bitbar.author.github>
 // <bitbar.image>https://i.imgur.com/x1SoIto.jpg</bitbar.image>

--- a/slack-team-notifications.1m.js
+++ b/slack-team-notifications.1m.js
@@ -19,6 +19,8 @@ const DARK_MODE = process.env.BitBarDarkMode;
 // If MENTIONS_ONLY is true, the count only includes mentions and DMs.
 // If MENTIONS_ONLY is false, the count includes all unread messages.
 const MENTIONS_ONLY = false;
+// MAX_LENGTH of channel name or user name
+const MAX_LENGTH = 15;
 
 // Is Slack.app installed?
 let SLACK_INSTALLED = true;
@@ -186,10 +188,10 @@ function channel_output(channel) {
 	unread_count += channel.count;
 
 	let output_str = (channel.is_im ? '@' : '#') + channel.name;
-	if (output_str.length > 15) {
-		output_str = output_str.substring(0, 14) + '…';
+	if (output_str.length > MAX_LENGTH) {
+		output_str = output_str.substring(0, MAX_LENGTH - 1) + '…';
 	}
-	output_str += ' '.repeat(17 - output_str.length);
+	output_str += ' '.repeat(MAX_LENGTH + 2 - output_str.length);
 	output_str += (channel.count > 10 ? '10+' : channel.count);
 
 	let key = channel.is_im ? SLACK_IM : channel.is_channel ? SLACK_CHANNELS : SLACK_GROUPS;

--- a/slack-team-notifications.1m.js
+++ b/slack-team-notifications.1m.js
@@ -98,7 +98,7 @@ if (process.argv.indexOf('--mark') > 0) {
 			slack_request(args[0] + SLACK_MARK, {
 				'token': token,
 				'channel': channels[j],
-				'ts': Math.floor(Date.now() / 1000)
+				'ts': Math.floor(Date.now() / 1000) + '.000000'
 			})
 				.then((body) => {
 					// console.log('  Success: ' + args[0] + ':' + channels[j]);

--- a/slack-team-notifications.1m.js
+++ b/slack-team-notifications.1m.js
@@ -20,7 +20,7 @@ const DARK_MODE = process.env.BitBarDarkMode;
 // If MENTIONS_ONLY is false, the count includes all unread messages.
 const MENTIONS_ONLY = false;
 // MAX_LENGTH of channel name or user name
-const MAX_LENGTH = 15;
+const MAX_LENGTH = 18;
 
 // Is Slack.app installed?
 let SLACK_INSTALLED = true;
@@ -129,6 +129,7 @@ function slack_request(URL, query) {
 		.get(SLACK_API + URL)
 		.query(query)
 		.then((res) => {
+			debug(res.body);
 			if (res && res.body && res.body.ok === true) {
 				return Promise.resolve(res.body);
 			}

--- a/slack-team-notifications.1m.js
+++ b/slack-team-notifications.1m.js
@@ -97,7 +97,7 @@ if (process.argv.indexOf('--mark') > 0) {
 		let channels = args[1].split(',');
 		for (let j in channels) {
 			console.log('/' + args[0] + SLACK_MARK + ' (' + channels[j] + ')');
-			slack_request(args[0] + SLACK_MARK, {
+			slack_request(SLACK_CONVERSATIONS + SLACK_MARK, {
 				'token': token,
 				'channel': channels[j],
 				'ts': Math.floor(Date.now() / 1000) + '.000000'


### PR DESCRIPTION
Fix:
- [conversations.mark](https://api.slack.com/methods/conversations.mark) replace previous `Mark as read` methods
- Timestamp format changed

Improvement:
- Add `MAX_LENGTH` variable that can be changed by user